### PR TITLE
Snakemake Temporary File Creation

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -28,7 +28,7 @@ rule filter_duplicate_individuals:
 		"filter_benchmarks/duplicates_filtered/{sample}.txt"
 	output:
 		dup = "duplicates_filtered/dup_ids/{sample}.txt",
-		ped = "duplicates_filtered/{sample}.ped",
+		ped = temp("duplicates_filtered/{sample}.ped"),
 		csv = "filter_logs/{sample}.csv"
 	shell:
 		"python bin/duplicate_filter.py {input.id} {output.dup} {input.ped} {output.ped}; python bin/duplicate_logging.py {output.dup} {output.csv}"
@@ -98,21 +98,21 @@ rule filter_variants:
 	benchmark:
 		"filter_benchmarks/filter_variants/{sample}.txt"
 	output:
-		bed="snp_filtered/{sample}.bed",
-		bim="snp_filtered/{sample}.bim",
-		fam="snp_filtered/{sample}.fam",
+		bed=temp("snp_filtered/{sample}.bed"),
+		bim=temp("snp_filtered/{sample}.bim"),
+		fam=temp("snp_filtered/{sample}.fam"),
 		log="snp_filtered/{sample}.log"
 	shell:
 		"plink --file {params.inprefix} --map {input.map} --threads 4 --keep-allele-order --cow --not-chr 0 --exclude maps/map_issues/snp_ids_to_exclude.txt --geno .1 --make-bed --out {params.oprefix}; python bin/snp_filtered_log_parsing.py {output.log} {params.csv}"
 
 rule convert_chip2seq:
-		input:  
+		input:
 			bed="snp_filtered/{sample}.bed",
 			bim="snp_filtered/{sample}.bim",
 			fam="snp_filtered/{sample}.fam",
 			refalt = "ref_alt/update_all_alleles_170531.txt",
 			log="snp_filtered/{sample}.log"
-		params: 
+		params:
 				iprefix="snp_filtered/{sample}",
 				oprefix = "ref_alt/{sample}"
 		threads : 4
@@ -120,31 +120,31 @@ rule convert_chip2seq:
 				"benchmarks/convert_chip2seq/{sample}.txt"
 		log:
 				"logs/convert_chip2seq/{sample}.log"
-		output: 
-				bed="ref_alt/{sample}.bed",
-				bim="ref_alt/{sample}.bim",
-				fam="ref_alt/{sample}.fam",
+		output:
+				bed=temp("ref_alt/{sample}.bed"),
+				bim=temp("ref_alt/{sample}.bim"),
+				fam=temp("ref_alt/{sample}.fam"),
 				log="ref_alt/{sample}.log"
-		shell:  
+		shell:
 				"(plink --bfile {params.iprefix} --cow  --threads 4 --out {params.oprefix} --exclude ref_alt/no_ref_alt_170603.txt  --update-alleles {input.refalt}  --make-bed)> {log}"
-				
+
 rule update_ref:
-		input:  
+		input:
 			rules.convert_chip2seq.output,
 			updateref = "ref_alt/update_all_refs_170531.txt"
-		params: 
+		params:
 				iprefix="ref_alt/{sample}",
 				oprefix = "ref_set/{sample}"
 		benchmark:
 				"benchmarks/update_ref/{sample}.txt"
 		log:
 				"logs/update_ref/{sample}.log"
-		output: 
-				bed="ref_set/{sample}.bed",
-				bim="ref_set/{sample}.bim",
-				fam="ref_set/{sample}.fam",
+		output:
+				bed=temp("ref_set/{sample}.bed"),
+				bim=temp("ref_set/{sample}.bim"),
+				fam=temp("ref_set/{sample}.fam"),
 				log="ref_set/{sample}.log"
-		shell:  
+		shell:
 				"(plink --bfile {params.iprefix} --cow  --out {params.oprefix} --a1-allele {input.updateref}  --make-bed)> {log}"
 
 
@@ -202,9 +202,9 @@ rule filter_individuals:
 	benchmark:
 		"filter_benchmarks/filter_individuals/{sample}.txt"
 	output:
-		bed="individual_filtered/{sample}.bed",
-		bim="individual_filtered/{sample}.bim",
-		fam="individual_filtered/{sample}.fam",
+		bed=temp("individual_filtered/{sample}.bed"),
+		bim=temp("individual_filtered/{sample}.bim"),
+		fam=temp("individual_filtered/{sample}.fam"),
 		log="individual_filtered/{sample}.log"
 
 	shell:
@@ -255,9 +255,9 @@ rule filter_hwe_variants:
 	benchmark:
 		"filter_benchmarks/filter_hwe_variants/{sample}.txt"
 	output:
-		bed="hwe_filtered/{sample}.bed",
-		bim="hwe_filtered/{sample}.bim",
-		fam="hwe_filtered/{sample}.fam",
+		bed=temp("hwe_filtered/{sample}.bed"),
+		bim=temp("hwe_filtered/{sample}.bim"),
+		fam=temp("hwe_filtered/{sample}.fam"),
 		log="hwe_filtered/{sample}.log"
 	shell:
 		"plink --bfile {params.inprefix} --cow --nonfounders  --real-ref-alleles --hwe 1e-20 --make-bed --out {params.oprefix}; python bin/hwe_log_parsing.py {output.log} {params.csv}"
@@ -278,9 +278,9 @@ rule impute_sex:
 	benchmark:
 		"filter_benchmarks/impute_sex/{sample}.txt"
 	output:
-		bed="sex_impute/{sample}.bed",
-		bim="sex_impute/{sample}.bim",
-		fam="sex_impute/{sample}.fam",
+		bed=temp("sex_impute/{sample}.bed"),
+		bim=temp("sex_impute/{sample}.bim"),
+		fam=temp("sex_impute/{sample}.fam"),
 		log="sex_impute/{sample}.log",
 		sexcheck="sex_impute/{sample}.sexcheck",
 		txt="sex_impute/{sample}.missexed_animals.txt"
@@ -300,10 +300,10 @@ rule remove_missexed_animals:
 		inprefix="sex_impute/{sample}",
 		oprefix="correct_sex/{sample}"
 	output:
-		bed="correct_sex/{sample}.bed",
-                bim="correct_sex/{sample}.bim",
-                fam="correct_sex/{sample}.fam",
-                log="correct_sex/{sample}.log",
+		bed=temp("correct_sex/{sample}.bed"),
+		bim=temp("correct_sex/{sample}.bim"),
+		fam=temp("correct_sex/{sample}.fam"),
+		log=temp("correct_sex/{sample}.log"),
 	shell:
 		"plink --bfile {params.inprefix} --cow --remove {input.txt} --real-ref-alleles --make-bed --out {params.oprefix}"
 
@@ -326,10 +326,10 @@ rule merge_assays:
 		oprefix="merged_files/170112_merged"
 	output:
 		#mergefilelist= "correct_sex/allfiles.txt"
-                bim = "merged_files/170112_merged.bim",
-                fam = "merged_files/170112_merged.fam",
-                log = "merged_files/170112_merged.log",
-                bed = "merged_files/170112_merged.bed"
+		bim = "merged_files/170112_merged.bim",
+		fam = "merged_files/170112_merged.fam",
+		log = "merged_files/170112_merged.log",
+		bed = "merged_files/170112_merged.bed"
 	shell:
 		"python bin/file_list_maker.py correct_sex/allfiles.txt; plink --merge-list correct_sex/allfiles.txt  --cow --real-ref-alleles --make-bed --out {params.oprefix}"
 
@@ -364,23 +364,23 @@ rule split_chromosomes:
 
 
 rule assay_chromosomes:
-        input:
-                bed = expand( "correct_sex/{assay}.bed", assay = DATA),
-                bim = expand("correct_sex/{assay}.bim", assay = DATA),
-                fam = expand("correct_sex/{assay}.fam", assay = DATA),
-                log = expand("correct_sex/{assay}.log", assay = DATA)
-        params:
-                inprefix = "correct_sex/{sample}",
-                oprefix = "eagle_chrsplit/{sample}.chr{chr}",
-                chr = "{chr}"
-        benchmark:
-                "filter_benchmarks/eagle_chrsplit/{sample}.chr{chr}.txt"
-        log:
-                "snake_logs/eagle_split_chromosomes/{sample}.chr{chr}.log"
-        output:
-                bed = "assay_chrsplit/{sample}.chr{chr}.bed",
-                bim = "assay_chrsplit/{sample}.chr{chr}.bim",
-                fam = "assay_chrsplit/{sample}.chr{chr}.fam",
-                log = "assay_chrsplit/{sample}.chr{chr}.log"
-        shell:
-                "(plink --bfile {params.inprefix}  --real-ref-alleles --chr {params.chr} --make-bed  --nonfounders --cow --out {params.oprefix})> {log}"
+	input:
+		bed = expand( "correct_sex/{assay}.bed", assay = DATA),
+		bim = expand("correct_sex/{assay}.bim", assay = DATA),
+		fam = expand("correct_sex/{assay}.fam", assay = DATA),
+		log = expand("correct_sex/{assay}.log", assay = DATA)
+	params:
+		inprefix = "correct_sex/{sample}",
+		oprefix = "eagle_chrsplit/{sample}.chr{chr}",
+		chr = "{chr}"
+	benchmark:
+		"filter_benchmarks/eagle_chrsplit/{sample}.chr{chr}.txt"
+	log:
+		"snake_logs/eagle_split_chromosomes/{sample}.chr{chr}.log"
+	output:
+		bed = "assay_chrsplit/{sample}.chr{chr}.bed",
+		bim = "assay_chrsplit/{sample}.chr{chr}.bim",
+		fam = "assay_chrsplit/{sample}.chr{chr}.fam",
+		log = "assay_chrsplit/{sample}.chr{chr}.log"
+	shell:
+		"(plink --bfile {params.inprefix}  --real-ref-alleles --chr {params.chr} --make-bed  --nonfounders --cow --out {params.oprefix})> {log}"

--- a/impacc.snakefile
+++ b/impacc.snakefile
@@ -51,7 +51,7 @@ rule impute2_vcf:
 	benchmark:
 		"benchmarks/impute2_vcf/run{run}/{sample}.chr{chr}.benchmark.txt"
 	output:
-		vcf = "impute2_vcf/run{run}/{sample}.chr{chr}.imputed.vcf"
+		vcf = temp("impute2_vcf/run{run}/{sample}.chr{chr}.imputed.vcf")
 	shell:
 		"(plink --gen {input.gen} --sample {input.sample} --cow --real-ref-alleles --oxford-single-chr {params.chrom} --recode vcf --out {params.oprefix})>{log}"
 

--- a/impute2.snakefile
+++ b/impute2.snakefile
@@ -181,7 +181,7 @@ rule cat_chunks:
 	benchmark:
 		"benchmarks/cat_chunks/run{run}/{sample}.chr{chr}.benchmark.txt"
 	output:
-		cat = "impute2_chromosome/run{run}/{sample}.chr{chr}.phased.imputed.gen"
+		cat = temp("impute2_chromosome/run{run}/{sample}.chr{chr}.phased.imputed.gen")
 	shell:
 		"(cat {input.chunks} > {output.cat}) > {log}"#; cp eagle_phased_assays/*.run2*.sample impute2_chromosome/"
 

--- a/mm.snakefile
+++ b/mm.snakefile
@@ -76,7 +76,7 @@ rule reformat_leg:
 	benchmark:
 		"benchmarks/reformat_leg/run{run}/merged_refpanel.chr{chr}.{chunk}.phased.benchmark.txt"
 	output:
-		newleg = "minimac_ref_panel/ref_panels/run{run}/merged_refpanel.chr{chr}.{chunk}.phased.reformatted.legend"
+		newleg = temp("minimac_ref_panel/ref_panels/run{run}/merged_refpanel.chr{chr}.{chunk}.phased.reformatted.legend")
 	shell:
 		"(python bin/bcftools_legend_converter.py {params.chr} {input.refleg} {output.newleg}) > {log}"
 
@@ -89,7 +89,7 @@ rule cat_sample:
 	benchmark:
 		"benchmarks/reformat_samp/run{run}/merged_refpanel.chr{chr}.phased.benchmark.txt"
 	output:
-		newsample = "minimac_ref_panel/ref_panels/run{run}/merged_refpanel.chr{chr}.phased.reformatted.sample"
+		newsample = temp("minimac_ref_panel/ref_panels/run{run}/merged_refpanel.chr{chr}.phased.reformatted.sample")
 	shell:
 		"(python bin/bcftools_sample_converter.py {input.samples} {output.newsample}) > {log}"
 

--- a/phasing.snakefile
+++ b/phasing.snakefile
@@ -121,8 +121,8 @@ rule hap_leg:
 	benchmark:
 		"benchmarks/hap_leg/run{run}/{sample}.chr{chr}.phased.benchmark.txt"
 	output:
-		hap = "impute_input/run{run}/{sample}.chr{chr}.phased.haplotypes",
-		leg = "impute_input/run{run}/{sample}.chr{chr}.phased.legend",
+		hap = temp("impute_input/run{run}/{sample}.chr{chr}.phased.haplotypes"),
+		leg = temp("impute_input/run{run}/{sample}.chr{chr}.phased.legend"),
 		log = "impute_input/run{run}/logs/{sample}.chr{chr}.phased.log"
 	shell:
 		"(shapeit -convert --input-haps {params.inprefix} --output-log {output.log} --output-ref {params.oprefix}) > {log}"
@@ -200,7 +200,7 @@ rule eagle_merged_vcf:
 	params:
 		haps="eagle_merged/run{run}/hol_testset.merge.chr{chr}"
 	output:
-		vcf="eagle_merged_vcf/run{run}/hol_testset.merge.chr{chr}.phased.vcf",
+		vcf=temp("eagle_merged_vcf/run{run}/hol_testset.merge.chr{chr}.phased.vcf"),
 		log="eagle_merged_vcf/logs/run{run}/hol_testset.merge.chr{chr}.log"
 	shell:
 		"(shapeit -convert --input-haps {params.haps} --output-log {output.log} --output-vcf {output.vcf}) > {log}"
@@ -213,8 +213,8 @@ rule bgzip_vcf:
 	benchmark:
 		"benchmarks/bgzip_vcf/run{run}/hol_testset.merge.chr{chr}"
 	output:
-		vcfgz="eagle_merged_vcf/run{run}/hol_testset.merge.chr{chr}.phased.vcf.gz",
-		index="eagle_merged_vcf/run{run}/hol_testset.merge.chr{chr}.phased.vcf.gz.tbi"
+		vcfgz=temp("eagle_merged_vcf/run{run}/hol_testset.merge.chr{chr}.phased.vcf.gz"),
+		index=temp("eagle_merged_vcf/run{run}/hol_testset.merge.chr{chr}.phased.vcf.gz.tbi")
 	shell:
 		"(bgzip {input.vcf}; tabix {output.vcfgz}) > {log};"
 
@@ -252,7 +252,7 @@ rule vcf_per_assay: #filter the vcfs on a per assay basis
 	log:
 		"logs/vcf_per_assay/run{run}/{assay}.chr{chr}.log"
 	output:
-		vcf = "vcf_per_assay/run{run}/{assay}.chr{chr}.vcf",
+		vcf = temp("vcf_per_assay/run{run}/{assay}.chr{chr}.vcf"),
 	shell:
 		"(bcftools view {input.vcfgz} -R {input.keep_maps}  -S {input.keep_ids} -o {output.vcf}) > {log}"
 
@@ -267,9 +267,9 @@ rule vcf_to_hap:
 	log:
 		"logs/vcf_to_hap/run{run}/{assay}.chr{chr}.log"
 	output:
-		legend = "vcf_to_hap/run{run}/{assay}.chr{chr}.phased.legend",
-		haps = "vcf_to_hap/run{run}/{assay}.chr{chr}.phased.haplotypes",
-		sample = "vcf_to_hap/run{run}/{assay}.chr{chr}.phased.samples"
+		legend = temp("vcf_to_hap/run{run}/{assay}.chr{chr}.phased.legend"),
+		haps = temp("vcf_to_hap/run{run}/{assay}.chr{chr}.phased.haplotypes"),
+		sample = temp("vcf_to_hap/run{run}/{assay}.chr{chr}.phased.samples")
 	shell:
 		"(bcftools convert {input.vcf} --haplegendsample {output.haps},{output.legend},{output.sample}) > {log}" #Updated these to use the naming conventions that the shapeit tool outputs the run2 hap,leg,samples, so naming is consistent in Impute2.
 
@@ -284,7 +284,7 @@ rule vcf_to_haps: #doesn't approrpriately name "haps" haps
 	log:
 		"logs/vcf_to_haps/run{run}/{assay}.chr{chr}.log"
 	output:
-		hap = "vcf_to_haps/run{run}/{assay}.chr{chr}.phased.haps",
-		sample = "vcf_to_haps/run{run}/{assay}.chr{chr}.phased.sample"
+		hap = temp("vcf_to_haps/run{run}/{assay}.chr{chr}.phased.haps"),
+		sample = temp("vcf_to_haps/run{run}/{assay}.chr{chr}.phased.sample")
 	shell:
 		"(bcftools convert {input.vcf} --hapsample {output.hap},{output.sample} ) > {log}"


### PR DESCRIPTION
I've made a number of the files that Snakemake creates in the pipeline temporary. I leave the raw genotypes, phasing and imputation outputs as non-temp files so that re-running an element of the pipeline shouldn't be too time consuming.  